### PR TITLE
Updated app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 appleprtest
 ===========
 
-Testing PRs for Pocket Trailer
+Testing PRs for Trailer


### PR DESCRIPTION
The app hasn't been called Pocket Trailer in a while. This PR fixes that.